### PR TITLE
fix(`make_Z_full`): generate all monomials including cross-column products (#6)

### DIFF
--- a/frac_blp/frac_utils.py
+++ b/frac_blp/frac_utils.py
@@ -1,5 +1,7 @@
 """Utility helpers for building instruments and projections in FRAC."""
 
+from itertools import combinations_with_replacement
+
 import numpy as np
 from scipy import linalg as spla
 
@@ -29,6 +31,19 @@ def make_X(X_exo: np.ndarray | None, X_endo: np.ndarray | None) -> np.ndarray:
     return X
 
 
+def _monomials_of_degree(mat: np.ndarray, d: int) -> list[np.ndarray]:
+    n_obs, n_cols = mat.shape
+    if d == 0:
+        return [np.ones(n_obs)]
+    result = []
+    for combo in combinations_with_replacement(range(n_cols), d):
+        term = np.ones(n_obs)
+        for c in combo:
+            term = term * mat[:, c]
+        result.append(term)
+    return result
+
+
 def make_Z_full(
     Z: np.ndarray,
     X1_exo: np.ndarray | None = None,
@@ -55,30 +70,15 @@ def make_Z_full(
         raise ValueError("degree_Z must be non-negative.")
 
     n_obs, n_z = Z.shape
-    columns: list[np.ndarray] = []
-
-    n_x1 = 0 if X1_exo is None else X1_exo.shape[1]
+    effective_X1 = X1_exo if X1_exo is not None else np.ones((n_obs, 1))
     max_dx1 = degree_X1 if X1_exo is not None else 0
 
+    columns: list[np.ndarray] = []
     for d_z in range(degree_Z + 1):
-        z_indices = [None] if d_z == 0 else range(n_z)
-        for iz in z_indices:
-            base_z = np.ones(n_obs) if iz is None else Z[:, iz] ** d_z
-            # str_base_z = " " if iz is None else f"Z[:, {iz}] ** {d_z} "
-
+        for z_term in _monomials_of_degree(Z, d_z):
             for d_x1 in range(max_dx1 + 1):
-                x1_indices = [None] if d_x1 == 0 else range(n_x1)
-                for ix1 in x1_indices:
-                    if ix1 is None:
-                        term_x1 = np.ones(n_obs)
-                        # str_X1 = "1 "
-                    else:
-                        assert X1_exo is not None
-                        term_x1 = X1_exo[:, ix1] ** d_x1
-                        # str_X1 = f"X1_exo[:, {ix1}] ** {d_x1} "
-                    columns.append(base_z * term_x1)
-                    # print(f"{iz=}, {d_z=}, {ix1=}, {d_x1=}")
-                    # print("    " + str_base_z + " * " + str_X1)
+                for x1_term in _monomials_of_degree(effective_X1, d_x1):
+                    columns.append(z_term * x1_term)
 
     return np.column_stack(columns)
 

--- a/tests/test_frac_utils.py
+++ b/tests/test_frac_utils.py
@@ -43,6 +43,94 @@ def test_make_Z_full_with_degree_Z_and_degree_X1_of_2():
     np.testing.assert_allclose(result, expected)
 
 
+def test_make_Z_full_includes_cross_terms_for_multi_column_Z():
+    Z = np.array([[2.0, 5.0], [3.0, 6.0], [4.0, 7.0]])
+    result = make_Z_full(Z, degree_Z=2)
+    expected = np.column_stack(
+        [
+            np.ones(3),
+            Z[:, 0],
+            Z[:, 1],
+            Z[:, 0] ** 2,
+            Z[:, 0] * Z[:, 1],
+            Z[:, 1] ** 2,
+        ]
+    )
+    np.testing.assert_allclose(result, expected)
+
+
+def test_make_Z_full_includes_cross_terms_for_multi_column_X1():
+    Z = np.array([[2.0], [3.0]])
+    X1 = np.array([[4.0, 6.0], [5.0, 7.0]])
+    result = make_Z_full(Z, X1_exo=X1, degree_Z=1, degree_X1=1)
+    expected = np.column_stack(
+        [
+            np.ones(2),
+            X1[:, 0],
+            X1[:, 1],
+            Z[:, 0],
+            Z[:, 0] * X1[:, 0],
+            Z[:, 0] * X1[:, 1],
+        ]
+    )
+    np.testing.assert_allclose(result, expected)
+
+
+def test_make_Z_full_includes_cross_terms_for_multi_column_Z_and_X1():
+    Z = np.array([[2.0, 3.0], [4.0, 5.0]])
+    X1 = np.array([[6.0, 7.0], [8.0, 9.0]])
+    result = make_Z_full(Z, X1_exo=X1, degree_Z=2, degree_X1=2)
+    z0, z1 = Z[:, 0], Z[:, 1]
+    x0, x1 = X1[:, 0], X1[:, 1]
+    expected = np.column_stack(
+        [
+            # d_z=0
+            np.ones(2),
+            x0,
+            x1,
+            x0**2,
+            x0 * x1,
+            x1**2,
+            # d_z=1: z0
+            z0,
+            z0 * x0,
+            z0 * x1,
+            z0 * x0**2,
+            z0 * x0 * x1,
+            z0 * x1**2,
+            # d_z=1: z1
+            z1,
+            z1 * x0,
+            z1 * x1,
+            z1 * x0**2,
+            z1 * x0 * x1,
+            z1 * x1**2,
+            # d_z=2: z0^2
+            z0**2,
+            z0**2 * x0,
+            z0**2 * x1,
+            z0**2 * x0**2,
+            z0**2 * x0 * x1,
+            z0**2 * x1**2,
+            # d_z=2: z0*z1
+            z0 * z1,
+            z0 * z1 * x0,
+            z0 * z1 * x1,
+            z0 * z1 * x0**2,
+            z0 * z1 * x0 * x1,
+            z0 * z1 * x1**2,
+            # d_z=2: z1^2
+            z1**2,
+            z1**2 * x0,
+            z1**2 * x1,
+            z1**2 * x0**2,
+            z1**2 * x0 * x1,
+            z1**2 * x1**2,
+        ]
+    )
+    np.testing.assert_allclose(result, expected)
+
+
 # `make_Z_full()` does not yet implement `X2_exo` and `degree_X2` arguments
 @pytest.mark.skip
 def test_make_Z_full_builds_cross_terms_with_x1_and_x2():


### PR DESCRIPTION
* Previously, `make_Z_full` raised each column of `Z` and `X1_exo` to a power independently, missing cross-column products (e.g. `Z[:,0]*Z[:,1]`) when either matrix had more than one column.
* Replace the per-column loop with `combinations_with_replacement` to correctly enumerate all monomials of each degree.

closes #6
